### PR TITLE
feat: add family/shared subscription feature

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -21,10 +21,38 @@ const applicationTables = {
     website: v.optional(v.string()),
     isActive: v.boolean(),
     notes: v.optional(v.string()),
+    // Family plan fields
+    maxSlots: v.optional(v.number()), // e.g., 5 for a family plan
   })
     .index("by_user", ["userId"])
     .index("by_user_and_active", ["userId", "isActive"])
     .index("by_next_billing", ["nextBillingDate"]),
+
+  // Subscription sharing - links subscriptions to beneficiaries
+  subscriptionShares: defineTable({
+    subscriptionId: v.id("subscriptions"),
+    // Either a real user or just a name (anonymous)
+    type: v.union(v.literal("user"), v.literal("anonymous")),
+    userId: v.optional(v.id("users")), // if type === "user"
+    name: v.optional(v.string()), // if type === "anonymous" (e.g., "Mom")
+    // Beneficiary preference
+    isHidden: v.boolean(), // beneficiary can hide from their list
+    createdAt: v.number(),
+  })
+    .index("by_subscription", ["subscriptionId"])
+    .index("by_user", ["userId"])
+    .index("by_user_and_hidden", ["userId", "isHidden"]),
+
+  // Invite links for sharing subscriptions
+  shareInvites: defineTable({
+    subscriptionId: v.id("subscriptions"),
+    token: v.string(),
+    expiresAt: v.number(),
+    claimedBy: v.optional(v.id("users")),
+    createdAt: v.number(),
+  })
+    .index("by_token", ["token"])
+    .index("by_subscription", ["subscriptionId"]),
 
   paymentMethods: defineTable({
     userId: v.id("users"),

--- a/convex/sharing.ts
+++ b/convex/sharing.ts
@@ -1,0 +1,569 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { v } from "convex/values";
+import { internalMutation, mutation, query } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+
+// Helper to get authenticated user
+async function getLoggedInUser(ctx: any) {
+  const userId = await getAuthUserId(ctx);
+  if (!userId) {
+    throw new Error("User not authenticated");
+  }
+  return userId;
+}
+
+// Generate a random token for invite links
+function generateToken(): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = 0; i < 32; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+/**
+ * Add an anonymous share (just a name, no user account needed)
+ */
+export const addAnonymousShare = mutation({
+  args: {
+    subscriptionId: v.id("subscriptions"),
+    name: v.string(),
+  },
+  returns: v.id("subscriptionShares"),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    // Verify ownership of subscription
+    const subscription = await ctx.db.get(args.subscriptionId);
+    if (!subscription || subscription.userId !== userId) {
+      throw new Error("Subscription not found or access denied");
+    }
+
+    return await ctx.db.insert("subscriptionShares", {
+      subscriptionId: args.subscriptionId,
+      type: "anonymous",
+      name: args.name,
+      isHidden: false,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+/**
+ * Create an invite link for sharing a subscription
+ */
+export const createInviteLink = mutation({
+  args: {
+    subscriptionId: v.id("subscriptions"),
+    expiresInDays: v.optional(v.number()),
+  },
+  returns: v.object({
+    token: v.string(),
+    expiresAt: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    // Verify ownership of subscription
+    const subscription = await ctx.db.get(args.subscriptionId);
+    if (!subscription || subscription.userId !== userId) {
+      throw new Error("Subscription not found or access denied");
+    }
+
+    const token = generateToken();
+    const expiresAt = Date.now() + (args.expiresInDays || 7) * 24 * 60 * 60 * 1000;
+
+    await ctx.db.insert("shareInvites", {
+      subscriptionId: args.subscriptionId,
+      token,
+      expiresAt,
+      createdAt: Date.now(),
+    });
+
+    return { token, expiresAt };
+  },
+});
+
+/**
+ * Get invite info by token (for preview before claiming)
+ */
+export const getInviteInfo = query({
+  args: { token: v.string() },
+  returns: v.union(
+    v.object({
+      valid: v.literal(true),
+      subscriptionName: v.string(),
+      ownerName: v.optional(v.string()),
+      cost: v.number(),
+      currency: v.string(),
+      billingCycle: v.string(),
+      maxSlots: v.optional(v.number()),
+      expiresAt: v.number(),
+    }),
+    v.object({
+      valid: v.literal(false),
+      reason: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const invite = await ctx.db
+      .query("shareInvites")
+      .withIndex("by_token", (q) => q.eq("token", args.token))
+      .first();
+
+    if (!invite) {
+      return { valid: false as const, reason: "Invite not found" };
+    }
+
+    if (invite.claimedBy) {
+      return { valid: false as const, reason: "Invite already claimed" };
+    }
+
+    if (invite.expiresAt < Date.now()) {
+      return { valid: false as const, reason: "Invite expired" };
+    }
+
+    const subscription = await ctx.db.get(invite.subscriptionId);
+    if (!subscription) {
+      return { valid: false as const, reason: "Subscription no longer exists" };
+    }
+
+    const owner = await ctx.db.get(subscription.userId);
+
+    return {
+      valid: true as const,
+      subscriptionName: subscription.name,
+      ownerName: owner?.name,
+      cost: subscription.cost,
+      currency: subscription.currency,
+      billingCycle: subscription.billingCycle,
+      maxSlots: subscription.maxSlots,
+      expiresAt: invite.expiresAt,
+    };
+  },
+});
+
+/**
+ * Claim an invite link (authenticated user becomes beneficiary)
+ */
+export const claimInvite = mutation({
+  args: { token: v.string() },
+  returns: v.union(
+    v.object({
+      success: v.literal(true),
+      subscriptionId: v.id("subscriptions"),
+    }),
+    v.object({
+      success: v.literal(false),
+      reason: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    const invite = await ctx.db
+      .query("shareInvites")
+      .withIndex("by_token", (q) => q.eq("token", args.token))
+      .first();
+
+    if (!invite) {
+      return { success: false as const, reason: "Invite not found" };
+    }
+
+    if (invite.claimedBy) {
+      return { success: false as const, reason: "Invite already claimed" };
+    }
+
+    if (invite.expiresAt < Date.now()) {
+      return { success: false as const, reason: "Invite expired" };
+    }
+
+    const subscription = await ctx.db.get(invite.subscriptionId);
+    if (!subscription) {
+      return { success: false as const, reason: "Subscription no longer exists" };
+    }
+
+    // Check if user is the owner
+    if (subscription.userId === userId) {
+      return { success: false as const, reason: "You cannot share with yourself" };
+    }
+
+    // Check if already shared with this user
+    const existingShare = await ctx.db
+      .query("subscriptionShares")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", invite.subscriptionId))
+      .filter((q) => q.eq(q.field("userId"), userId))
+      .first();
+
+    if (existingShare) {
+      return { success: false as const, reason: "Already shared with you" };
+    }
+
+    // Create the share
+    await ctx.db.insert("subscriptionShares", {
+      subscriptionId: invite.subscriptionId,
+      type: "user",
+      userId,
+      isHidden: false,
+      createdAt: Date.now(),
+    });
+
+    // Mark invite as claimed
+    await ctx.db.patch(invite._id, { claimedBy: userId });
+
+    return { success: true as const, subscriptionId: invite.subscriptionId };
+  },
+});
+
+/**
+ * Get shares for a subscription (owner view)
+ */
+export const getSubscriptionShares = query({
+  args: { subscriptionId: v.id("subscriptions") },
+  returns: v.array(
+    v.object({
+      _id: v.id("subscriptionShares"),
+      type: v.union(v.literal("user"), v.literal("anonymous")),
+      name: v.optional(v.string()),
+      userId: v.optional(v.id("users")),
+      userName: v.optional(v.string()),
+      createdAt: v.number(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    // Verify ownership
+    const subscription = await ctx.db.get(args.subscriptionId);
+    if (!subscription || subscription.userId !== userId) {
+      throw new Error("Subscription not found or access denied");
+    }
+
+    const shares = await ctx.db
+      .query("subscriptionShares")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", args.subscriptionId))
+      .collect();
+
+    return await Promise.all(
+      shares.map(async (share) => {
+        let userName: string | undefined;
+        if (share.type === "user" && share.userId) {
+          const user = await ctx.db.get(share.userId);
+          userName = user?.name ?? user?.email ?? undefined;
+        }
+        return {
+          _id: share._id,
+          type: share.type,
+          name: share.name,
+          userId: share.userId,
+          userName,
+          createdAt: share.createdAt,
+        };
+      }),
+    );
+  },
+});
+
+/**
+ * Remove a share (owner action)
+ */
+export const removeShare = mutation({
+  args: { shareId: v.id("subscriptionShares") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    const share = await ctx.db.get(args.shareId);
+    if (!share) {
+      throw new Error("Share not found");
+    }
+
+    // Verify ownership of the subscription
+    const subscription = await ctx.db.get(share.subscriptionId);
+    if (!subscription || subscription.userId !== userId) {
+      throw new Error("Access denied");
+    }
+
+    await ctx.db.delete(args.shareId);
+    return null;
+  },
+});
+
+/**
+ * Toggle hide status for a shared subscription (beneficiary action)
+ */
+export const toggleHideShare = mutation({
+  args: { shareId: v.id("subscriptionShares") },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    const share = await ctx.db.get(args.shareId);
+    if (!share) {
+      throw new Error("Share not found");
+    }
+
+    // Verify this share belongs to the current user
+    if (share.type !== "user" || share.userId !== userId) {
+      throw new Error("Access denied");
+    }
+
+    const newHiddenState = !share.isHidden;
+    await ctx.db.patch(args.shareId, { isHidden: newHiddenState });
+    return newHiddenState;
+  },
+});
+
+/**
+ * Get subscriptions shared with the current user (beneficiary view)
+ */
+export const getSharedWithMe = query({
+  args: { includeHidden: v.optional(v.boolean()) },
+  returns: v.array(
+    v.object({
+      shareId: v.id("subscriptionShares"),
+      subscriptionId: v.id("subscriptions"),
+      name: v.string(),
+      cost: v.number(),
+      currency: v.string(),
+      billingCycle: v.union(
+        v.literal("monthly"),
+        v.literal("yearly"),
+        v.literal("weekly"),
+        v.literal("daily"),
+      ),
+      nextBillingDate: v.number(),
+      maxSlots: v.optional(v.number()),
+      ownerName: v.optional(v.string()),
+      isHidden: v.boolean(),
+      isActive: v.boolean(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    let sharesQuery = ctx.db
+      .query("subscriptionShares")
+      .withIndex("by_user", (q) => q.eq("userId", userId));
+
+    if (!args.includeHidden) {
+      sharesQuery = ctx.db
+        .query("subscriptionShares")
+        .withIndex("by_user_and_hidden", (q) => q.eq("userId", userId).eq("isHidden", false));
+    }
+
+    const shares = await sharesQuery.collect();
+
+    const results = await Promise.all(
+      shares.map(async (share) => {
+        const subscription = await ctx.db.get(share.subscriptionId);
+        if (!subscription) return null;
+
+        const owner = await ctx.db.get(subscription.userId);
+
+        return {
+          shareId: share._id,
+          subscriptionId: subscription._id,
+          name: subscription.name,
+          cost: subscription.cost,
+          currency: subscription.currency,
+          billingCycle: subscription.billingCycle,
+          nextBillingDate: subscription.nextBillingDate,
+          maxSlots: subscription.maxSlots,
+          ownerName: owner?.name ?? owner?.email ?? undefined,
+          isHidden: share.isHidden,
+          isActive: subscription.isActive,
+        };
+      }),
+    );
+
+    return results.filter((r): r is NonNullable<typeof r> => r !== null);
+  },
+});
+
+/**
+ * Get pending invites for a subscription (owner can see/revoke)
+ */
+export const getPendingInvites = query({
+  args: { subscriptionId: v.id("subscriptions") },
+  returns: v.array(
+    v.object({
+      _id: v.id("shareInvites"),
+      token: v.string(),
+      expiresAt: v.number(),
+      createdAt: v.number(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    // Verify ownership
+    const subscription = await ctx.db.get(args.subscriptionId);
+    if (!subscription || subscription.userId !== userId) {
+      throw new Error("Subscription not found or access denied");
+    }
+
+    const invites = await ctx.db
+      .query("shareInvites")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", args.subscriptionId))
+      .filter((q) =>
+        q.and(q.eq(q.field("claimedBy"), undefined), q.gt(q.field("expiresAt"), Date.now())),
+      )
+      .collect();
+
+    return invites.map((inv) => ({
+      _id: inv._id,
+      token: inv.token,
+      expiresAt: inv.expiresAt,
+      createdAt: inv.createdAt,
+    }));
+  },
+});
+
+/**
+ * Revoke an invite link
+ */
+export const revokeInvite = mutation({
+  args: { inviteId: v.id("shareInvites") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    const invite = await ctx.db.get(args.inviteId);
+    if (!invite) {
+      throw new Error("Invite not found");
+    }
+
+    // Verify ownership of the subscription
+    const subscription = await ctx.db.get(invite.subscriptionId);
+    if (!subscription || subscription.userId !== userId) {
+      throw new Error("Access denied");
+    }
+
+    await ctx.db.delete(args.inviteId);
+    return null;
+  },
+});
+
+/**
+ * Calculate ROI/waste for a family subscription (owner view)
+ */
+export const getSubscriptionROI = query({
+  args: { subscriptionId: v.id("subscriptions") },
+  returns: v.union(
+    v.object({
+      hasSlots: v.literal(true),
+      maxSlots: v.number(),
+      usedSlots: v.number(), // includes owner
+      unusedSlots: v.number(),
+      costPerSlot: v.number(),
+      wastedAmount: v.number(),
+      currency: v.string(),
+    }),
+    v.object({
+      hasSlots: v.literal(false),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const userId = await getLoggedInUser(ctx);
+
+    const subscription = await ctx.db.get(args.subscriptionId);
+    if (!subscription || subscription.userId !== userId) {
+      throw new Error("Subscription not found or access denied");
+    }
+
+    if (!subscription.maxSlots) {
+      return { hasSlots: false as const };
+    }
+
+    const shares = await ctx.db
+      .query("subscriptionShares")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", args.subscriptionId))
+      .collect();
+
+    const usedSlots = shares.length + 1; // +1 for owner
+    const unusedSlots = Math.max(0, subscription.maxSlots - usedSlots);
+    const costPerSlot = subscription.cost / subscription.maxSlots;
+    const wastedAmount = unusedSlots * costPerSlot;
+
+    return {
+      hasSlots: true as const,
+      maxSlots: subscription.maxSlots,
+      usedSlots,
+      unusedSlots,
+      costPerSlot,
+      wastedAmount,
+      currency: subscription.currency,
+    };
+  },
+});
+
+/**
+ * Internal mutation to claim invite (used by HTTP route)
+ */
+export const claimInviteInternal = internalMutation({
+  args: {
+    token: v.string(),
+    userId: v.id("users"),
+  },
+  returns: v.union(
+    v.object({
+      success: v.literal(true),
+      subscriptionId: v.id("subscriptions"),
+    }),
+    v.object({
+      success: v.literal(false),
+      reason: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const invite = await ctx.db
+      .query("shareInvites")
+      .withIndex("by_token", (q) => q.eq("token", args.token))
+      .first();
+
+    if (!invite) {
+      return { success: false as const, reason: "Invite not found" };
+    }
+
+    if (invite.claimedBy) {
+      return { success: false as const, reason: "Invite already claimed" };
+    }
+
+    if (invite.expiresAt < Date.now()) {
+      return { success: false as const, reason: "Invite expired" };
+    }
+
+    const subscription = await ctx.db.get(invite.subscriptionId);
+    if (!subscription) {
+      return { success: false as const, reason: "Subscription no longer exists" };
+    }
+
+    if (subscription.userId === args.userId) {
+      return { success: false as const, reason: "You cannot share with yourself" };
+    }
+
+    const existingShare = await ctx.db
+      .query("subscriptionShares")
+      .withIndex("by_subscription", (q) => q.eq("subscriptionId", invite.subscriptionId))
+      .filter((q) => q.eq(q.field("userId"), args.userId))
+      .first();
+
+    if (existingShare) {
+      return { success: false as const, reason: "Already shared with you" };
+    }
+
+    await ctx.db.insert("subscriptionShares", {
+      subscriptionId: invite.subscriptionId,
+      type: "user",
+      userId: args.userId,
+      isHidden: false,
+      createdAt: Date.now(),
+    });
+
+    await ctx.db.patch(invite._id, { claimedBy: args.userId });
+
+    return { success: true as const, subscriptionId: invite.subscriptionId };
+  },
+});

--- a/convex/subscriptions.ts
+++ b/convex/subscriptions.ts
@@ -49,6 +49,7 @@ const subscriptionWithPaymentValidator = v.object({
   website: v.optional(v.string()),
   isActive: v.boolean(),
   notes: v.optional(v.string()),
+  maxSlots: v.optional(v.number()),
   paymentMethod: paymentMethodValidator,
 });
 
@@ -103,6 +104,7 @@ export const create = mutation({
     category: v.string(),
     website: v.optional(v.string()),
     notes: v.optional(v.string()),
+    maxSlots: v.optional(v.number()),
   },
   returns: v.id("subscriptions"),
   handler: async (ctx, args) => {
@@ -130,6 +132,7 @@ export const update = mutation({
     website: v.optional(v.string()),
     isActive: v.optional(v.boolean()),
     notes: v.optional(v.string()),
+    maxSlots: v.optional(v.number()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {

--- a/src/components/AddSubscriptionForm.tsx
+++ b/src/components/AddSubscriptionForm.tsx
@@ -19,6 +19,8 @@ export function AddSubscriptionForm({ paymentMethods }: AddSubscriptionFormProps
     category: "",
     website: "",
     notes: "",
+    isFamilyPlan: false,
+    maxSlots: "",
   });
 
   const { create: createSubscription } = useSubscriptionMutations();
@@ -59,6 +61,7 @@ export function AddSubscriptionForm({ paymentMethods }: AddSubscriptionFormProps
         category: formData.category,
         website: formData.website || undefined,
         notes: formData.notes || undefined,
+        maxSlots: formData.isFamilyPlan && formData.maxSlots ? parseInt(formData.maxSlots) : undefined,
       });
 
       toast.success("Subscription added successfully!");
@@ -73,6 +76,8 @@ export function AddSubscriptionForm({ paymentMethods }: AddSubscriptionFormProps
         category: "",
         website: "",
         notes: "",
+        isFamilyPlan: false,
+        maxSlots: "",
       });
     } catch (error) {
       toast.error("Failed to add subscription");
@@ -232,6 +237,50 @@ export function AddSubscriptionForm({ paymentMethods }: AddSubscriptionFormProps
               ))}
             </select>
           </div>
+        </div>
+
+        {/* Family Plan Section */}
+        <div className="border-t border-[rgba(113,113,122,0.15)] pt-5 mt-2">
+          <div className="flex items-center gap-3 mb-4">
+            <button
+              type="button"
+              onClick={() => setFormData({ ...formData, isFamilyPlan: !formData.isFamilyPlan, maxSlots: "" })}
+              className={`relative w-11 h-6 rounded-full transition-colors ${
+                formData.isFamilyPlan ? "bg-primary" : "bg-white/10"
+              }`}
+            >
+              <span
+                className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white transition-transform ${
+                  formData.isFamilyPlan ? "translate-x-5" : ""
+                }`}
+              />
+            </button>
+            <label className="text-sm font-medium text-secondary">
+              Family/Shared Plan
+            </label>
+          </div>
+
+          {formData.isFamilyPlan && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+              <div>
+                <label className="block text-sm font-medium text-secondary mb-2">
+                  Max Slots <span className="text-accent-coral">*</span>
+                </label>
+                <input
+                  type="number"
+                  min="2"
+                  required={formData.isFamilyPlan}
+                  value={formData.maxSlots}
+                  onChange={(e) => setFormData({ ...formData, maxSlots: e.target.value })}
+                  className="input-field"
+                  placeholder="e.g., 5 for a family plan"
+                />
+                <p className="text-xs text-secondary/60 mt-1">
+                  Total number of people who can use this subscription
+                </p>
+              </div>
+            </div>
+          )}
         </div>
 
         <div>

--- a/src/components/InviteClaim.tsx
+++ b/src/components/InviteClaim.tsx
@@ -1,0 +1,177 @@
+import { Authenticated, Unauthenticated } from "convex/react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useInviteInfo, useSharingMutations } from "../lib/useSubscriptionData";
+import { SignInForm } from "../SignInForm";
+
+interface InviteClaimProps {
+  token: string;
+  onClose: () => void;
+}
+
+export function InviteClaim({ token, onClose }: InviteClaimProps) {
+  const [isClaiming, setIsClaiming] = useState(false);
+  const inviteInfo = useInviteInfo(token);
+  const { claimInvite } = useSharingMutations();
+
+  const handleClaim = async () => {
+    setIsClaiming(true);
+    try {
+      const result = await claimInvite(token);
+      if (result.success) {
+        toast.success("Subscription added to your list!");
+        // Redirect to dashboard
+        window.history.pushState({}, "", "/");
+        onClose();
+      } else {
+        toast.error(result.reason);
+      }
+    } catch (error) {
+      toast.error("Failed to claim invite");
+      console.error(error);
+    } finally {
+      setIsClaiming(false);
+    }
+  };
+
+  const formatCurrency = (amount: number, currency: string) => {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: currency,
+    }).format(amount);
+  };
+
+  // Loading state
+  if (inviteInfo === undefined) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="spinner" />
+      </div>
+    );
+  }
+
+  // Invalid invite
+  if (!inviteInfo.valid) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-6">
+        <div className="glass-card max-w-md w-full p-8 text-center">
+          <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-accent-coral/20 flex items-center justify-center">
+            <svg
+              className="w-8 h-8 text-accent-coral"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-semibold text-white mb-2">Invalid Invite</h2>
+          <p className="text-secondary mb-6">{inviteInfo.reason}</p>
+          <button onClick={onClose} className="btn-primary w-full">
+            Go to Dashboard
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Valid invite - show preview
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="glass-card max-w-md w-full overflow-hidden">
+        <div className="px-6 py-5 border-b border-[rgba(113,113,122,0.15)]">
+          <h2 className="text-xl font-semibold text-white">You've been invited!</h2>
+        </div>
+
+        <div className="p-6">
+          {/* Subscription Preview */}
+          <div className="p-4 rounded-xl bg-white/5 border border-[rgba(113,113,122,0.15)] mb-6">
+            <h3 className="text-lg font-semibold text-white mb-2">{inviteInfo.subscriptionName}</h3>
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-secondary">Cost</span>
+                <span className="text-white">
+                  {formatCurrency(inviteInfo.cost, inviteInfo.currency)} / {inviteInfo.billingCycle}
+                </span>
+              </div>
+              {inviteInfo.ownerName && (
+                <div className="flex justify-between">
+                  <span className="text-secondary">Paid by</span>
+                  <span className="text-white">{inviteInfo.ownerName}</span>
+                </div>
+              )}
+              {inviteInfo.maxSlots && (
+                <div className="flex justify-between">
+                  <span className="text-secondary">Plan type</span>
+                  <span className="text-white">Family ({inviteInfo.maxSlots} slots)</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <Authenticated>
+            <button
+              onClick={handleClaim}
+              disabled={isClaiming}
+              className="btn-primary w-full flex items-center justify-center gap-2"
+            >
+              {isClaiming ? (
+                <>
+                  <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  Adding...
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 4v16m8-8H4"
+                    />
+                  </svg>
+                  Add to My Subscriptions
+                </>
+              )}
+            </button>
+            <p className="text-xs text-secondary/60 text-center mt-3">
+              This subscription will appear in your list with limited details
+            </p>
+          </Authenticated>
+
+          <Unauthenticated>
+            <div className="text-center mb-4">
+              <p className="text-secondary text-sm">Sign in to accept this invite</p>
+            </div>
+            <SignInForm />
+          </Unauthenticated>
+        </div>
+
+        <div className="px-6 py-4 border-t border-[rgba(113,113,122,0.15)] bg-white/[0.02]">
+          <button onClick={onClose} className="text-secondary hover:text-white text-sm transition-colors">
+            Cancel and go to dashboard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ShareManagement.tsx
+++ b/src/components/ShareManagement.tsx
@@ -1,0 +1,364 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  usePendingInvites,
+  useSharingMutations,
+  useSubscriptionROI,
+  useSubscriptionShares,
+} from "../lib/useSubscriptionData";
+
+interface ShareManagementProps {
+  subscriptionId: string;
+  subscriptionName: string;
+  maxSlots?: number;
+  onClose: () => void;
+}
+
+export function ShareManagement({
+  subscriptionId,
+  subscriptionName,
+  maxSlots,
+  onClose,
+}: ShareManagementProps) {
+  const [newMemberName, setNewMemberName] = useState("");
+  const [isCreatingInvite, setIsCreatingInvite] = useState(false);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  const shares = useSubscriptionShares(subscriptionId);
+  const pendingInvites = usePendingInvites(subscriptionId);
+  const roi = useSubscriptionROI(subscriptionId);
+  const { addAnonymousShare, createInviteLink, removeShare, revokeInvite } = useSharingMutations();
+
+  const handleAddAnonymousMember = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newMemberName.trim()) return;
+
+    try {
+      await addAnonymousShare(subscriptionId, newMemberName.trim());
+      toast.success(`Added ${newMemberName} to the plan`);
+      setNewMemberName("");
+    } catch (error) {
+      toast.error("Failed to add member");
+      console.error(error);
+    }
+  };
+
+  const handleCreateInviteLink = async () => {
+    setIsCreatingInvite(true);
+    try {
+      const result = await createInviteLink(subscriptionId, 7);
+      const inviteUrl = `${window.location.origin}/invite/${result.token}`;
+      await navigator.clipboard.writeText(inviteUrl);
+      toast.success("Invite link copied to clipboard!");
+      setCopiedToken(result.token);
+      setTimeout(() => setCopiedToken(null), 3000);
+    } catch (error) {
+      toast.error("Failed to create invite link");
+      console.error(error);
+    } finally {
+      setIsCreatingInvite(false);
+    }
+  };
+
+  const handleRemoveShare = async (shareId: string, name?: string) => {
+    if (confirm(`Remove ${name || "this member"} from the plan?`)) {
+      try {
+        await removeShare(shareId);
+        toast.success("Member removed");
+      } catch (error) {
+        toast.error("Failed to remove member");
+        console.error(error);
+      }
+    }
+  };
+
+  const handleRevokeInvite = async (inviteId: string) => {
+    try {
+      await revokeInvite(inviteId);
+      toast.success("Invite revoked");
+    } catch (error) {
+      toast.error("Failed to revoke invite");
+      console.error(error);
+    }
+  };
+
+  const copyInviteLink = async (token: string) => {
+    const inviteUrl = `${window.location.origin}/invite/${token}`;
+    await navigator.clipboard.writeText(inviteUrl);
+    toast.success("Invite link copied!");
+    setCopiedToken(token);
+    setTimeout(() => setCopiedToken(null), 3000);
+  };
+
+  const formatCurrency = (amount: number, currency: string) => {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: currency,
+    }).format(amount);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="glass-card max-w-lg w-full max-h-[90vh] overflow-y-auto">
+        <div className="px-6 py-5 border-b border-[rgba(113,113,122,0.15)] flex justify-between items-center sticky top-0 bg-[#18181b]">
+          <div>
+            <h3 className="font-semibold text-white">Manage Sharing</h3>
+            <p className="text-sm text-secondary mt-1">{subscriptionName}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-secondary hover:text-white hover:bg-white/5 transition-all"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-6 space-y-6">
+          {/* ROI Section */}
+          {roi && roi.hasSlots && (
+            <div className="p-4 rounded-xl bg-white/5 border border-[rgba(113,113,122,0.15)]">
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-sm font-medium text-secondary">Plan Usage</span>
+                <span className="text-sm text-white">
+                  {roi.usedSlots} / {roi.maxSlots} slots
+                </span>
+              </div>
+              <div className="w-full h-2 bg-white/10 rounded-full overflow-hidden mb-3">
+                <div
+                  className="h-full bg-primary rounded-full transition-all"
+                  style={{ width: `${(roi.usedSlots / roi.maxSlots) * 100}%` }}
+                />
+              </div>
+              {roi.unusedSlots > 0 && (
+                <div className="flex items-center gap-2 text-accent-coral">
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                  </svg>
+                  <span className="text-sm">
+                    {roi.unusedSlots} unused slot{roi.unusedSlots > 1 ? "s" : ""} -{" "}
+                    {formatCurrency(roi.wastedAmount, roi.currency)}/cycle wasted
+                  </span>
+                </div>
+              )}
+              {roi.unusedSlots === 0 && (
+                <div className="flex items-center gap-2 text-accent-teal">
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  <span className="text-sm">All slots in use - great value!</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Current Members */}
+          <div>
+            <h4 className="text-sm font-medium text-secondary mb-3">
+              Shared With ({shares?.length || 0})
+            </h4>
+            {shares && shares.length > 0 ? (
+              <div className="space-y-2">
+                {shares.map((share) => (
+                  <div
+                    key={share._id}
+                    className="flex items-center justify-between p-3 rounded-lg bg-white/5"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center">
+                        <span className="text-sm font-medium text-primary">
+                          {(share.userName || share.name || "?")[0].toUpperCase()}
+                        </span>
+                      </div>
+                      <div>
+                        <p className="text-sm text-white">{share.userName || share.name}</p>
+                        <p className="text-xs text-secondary">
+                          {share.type === "user" ? "App user" : "Added manually"}
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => handleRemoveShare(share._id, share.userName || share.name)}
+                      className="p-2 rounded-lg text-secondary hover:text-accent-coral hover:bg-white/5 transition-all"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-secondary/60">No one added yet</p>
+            )}
+          </div>
+
+          {/* Add Anonymous Member */}
+          <div>
+            <h4 className="text-sm font-medium text-secondary mb-3">Add Member (by name)</h4>
+            <form onSubmit={handleAddAnonymousMember} className="flex gap-2">
+              <input
+                type="text"
+                value={newMemberName}
+                onChange={(e) => setNewMemberName(e.target.value)}
+                placeholder="e.g., Mom, Dad, Sister..."
+                className="input-field flex-1"
+              />
+              <button type="submit" className="btn-primary" disabled={!newMemberName.trim()}>
+                Add
+              </button>
+            </form>
+            <p className="text-xs text-secondary/60 mt-2">
+              For people who don't use this app - just track them by name
+            </p>
+          </div>
+
+          {/* Invite Link */}
+          <div>
+            <h4 className="text-sm font-medium text-secondary mb-3">Invite via Link</h4>
+            <button
+              onClick={handleCreateInviteLink}
+              disabled={isCreatingInvite}
+              className="btn-secondary w-full flex items-center justify-center gap-2"
+            >
+              {isCreatingInvite ? (
+                <>
+                  <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  Creating...
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                    />
+                  </svg>
+                  Create Invite Link
+                </>
+              )}
+            </button>
+            <p className="text-xs text-secondary/60 mt-2">
+              For people who use this app - they'll see your subscription in their list
+            </p>
+          </div>
+
+          {/* Pending Invites */}
+          {pendingInvites && pendingInvites.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-secondary mb-3">Pending Invites</h4>
+              <div className="space-y-2">
+                {pendingInvites.map((invite) => (
+                  <div
+                    key={invite._id}
+                    className="flex items-center justify-between p-3 rounded-lg bg-white/5"
+                  >
+                    <div>
+                      <p className="text-sm text-white font-mono">
+                        ...{invite.token.slice(-8)}
+                      </p>
+                      <p className="text-xs text-secondary">
+                        Expires {new Date(invite.expiresAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => copyInviteLink(invite.token)}
+                        className="p-2 rounded-lg text-secondary hover:text-primary hover:bg-white/5 transition-all"
+                      >
+                        {copiedToken === invite.token ? (
+                          <svg
+                            className="w-4 h-4 text-accent-teal"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M5 13l4 4L19 7"
+                            />
+                          </svg>
+                        ) : (
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                            />
+                          </svg>
+                        )}
+                      </button>
+                      <button
+                        onClick={() => handleRevokeInvite(invite._id)}
+                        className="p-2 rounded-lg text-secondary hover:text-accent-coral hover:bg-white/5 transition-all"
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M6 18L18 6M6 6l12 12"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add maxSlots field to subscriptions for family plans
- Create subscriptionShares and shareInvites tables for sharing
- Add sharing backend (convex/sharing.ts) with:
  - Anonymous shares (add members by name)
  - Invite link generation and claiming
  - ROI/waste calculation for unused slots
  - Hide/show toggle for beneficiaries
- Update AddSubscriptionForm with family plan toggle and maxSlots
- Create ShareManagement component for owners to manage shares
- Update SubscriptionList with sharing badges and controls
- Create InviteClaim page for accepting invite links
- Add URL detection for /invite/{token} paths

Owner view: Full subscription details, share management, ROI tracking
Beneficiary view: Limited info (cost, renewal, owner), hide option